### PR TITLE
Use NotFoundException instead \Exception, if a value could not be retrieved

### DIFF
--- a/Classes/Exception/NotFoundException.php
+++ b/Classes/Exception/NotFoundException.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Gressus\Tools\Exception;
+
+use Exception;
+
+class NotFoundException extends Exception
+{
+}

--- a/Classes/ObjectAccess.php
+++ b/Classes/ObjectAccess.php
@@ -11,6 +11,9 @@
  * @package Gressus_Tools
  ***************************************************************/
 namespace Gressus\Tools;
+
+use Gressus\Tools\Exception\NotFoundException;
+
 /**
  * Object Access
  *
@@ -19,8 +22,6 @@ namespace Gressus\Tools;
  * @author Felix Krüger <f3l1x@gressus.de>
  *
  */
-
-
 class ObjectAccess {
 
     /**
@@ -77,7 +78,7 @@ class ObjectAccess {
     public static function getOrThrowException($object, $query){
         $value = self::get($object,$query);
         if($value === null){
-            throw new \Exception('Could Not Retrieve '.$query);
+            throw new NotFoundException('Could Not Retrieve '.$query);
         }
         return $value;
     }


### PR DESCRIPTION
When trying to access a non existing property on an Object via `ObjectAccess::getOrThrowException()`, do throw a namespaced NotFoundException, instead \Exception, but keeping backward compatibility by extending \Exception.

This change allows code using the `getOrThrowException()` method to differentiate between Exceptions from ObjectAccess an other parts.